### PR TITLE
fix/cannot-run-app-1: App fails to start locally due to API key name was invalid.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Follow these instructions to get a copy of the project up and running on your lo
 
 3. Create a `.env` file in the root directory and add your Meteosource API key:
     ```env
-    REACT_APP_WEATHER_API_KEY=your_api_key_here
+    REACT_APP_API_KEY=your_api_key_here
     ```
 
 ### Usage


### PR DESCRIPTION
This PR fixes the problem described in fix/cannot-run-app-1 where the app could not run because the API key name was invalid in .env file.

**Changes made:**
Updated README with instructions on setting .env variables.

**How to test:**
1. Create a .env file with REACT_APP_API_KEY=your_key
2. Run the app using npm start or yarn start
3. Verify the app loads weather data without errors